### PR TITLE
Implement various layout optimizations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY: 'nightly-2023-09-30'
+  NIGHTLY: 'nightly-2025-01-01'
 
 jobs:
   check_lints:

--- a/byteyarn/src/boxed.rs
+++ b/byteyarn/src/boxed.rs
@@ -587,7 +587,7 @@ impl<'a> YarnBox<'a, [u8]> {
   }
 }
 
-impl<'a, T> YarnBox<'a, [T]>
+impl<T> YarnBox<'_, [T]>
 where
   [T]: crate::Buf,
 {

--- a/byteyarn/src/reffed.rs
+++ b/byteyarn/src/reffed.rs
@@ -293,7 +293,7 @@ impl<'a> YarnRef<'a, [u8]> {
   }
 }
 
-impl<'a> YarnRef<'a, str> {
+impl YarnRef<'_, str> {
   /// Converts this yarn into a string slice.
   pub fn as_str(&self) -> &str {
     self.as_slice()

--- a/ilex/src/file/context.rs
+++ b/ilex/src/file/context.rs
@@ -7,13 +7,10 @@ use camino::Utf8PathBuf;
 
 use crate::f;
 use crate::file::File;
-use crate::file::SpanId;
 use crate::file::CTX_FOR_SPAN_DEBUG;
 use crate::report;
 use crate::report::Fatal;
 use crate::report::Report;
-
-use super::Span;
 
 /// A source context, which owns source code files.
 ///
@@ -30,8 +27,6 @@ pub struct State {
   // TODO(mcyoung): Be smarter about this and use something something concurrent
   // vector? We don't need to have all this stuff behind a lock I think.
   files: Vec<(Utf8PathBuf, String)>,
-
-  ranges: Vec<Span>,
 }
 
 unsafe impl Send for Context {}
@@ -141,21 +136,5 @@ impl Context {
   /// Gets the number of files currently tracked by this source context.
   pub fn file_count(&self) -> usize {
     self.state.read().unwrap().files.len()
-  }
-
-  /// Gets the byte range for the given span, if it isn't the synthetic span.
-  pub(crate) fn lookup_range(&self, span: SpanId) -> Span {
-    let state = self.state.read().unwrap();
-    state.ranges[span.0 as usize]
-  }
-
-  /// Creates a new synthetic span with the given contents.
-  pub(crate) fn new_span(&self, range: Span) -> SpanId {
-    let mut state = self.state.write().unwrap();
-    assert!(state.ranges.len() <= (u32::MAX as usize), "ran out of spans");
-
-    let span = SpanId(state.ranges.len() as u32);
-    state.ranges.push(range);
-    span
   }
 }

--- a/ilex/src/file/context.rs
+++ b/ilex/src/file/context.rs
@@ -11,11 +11,13 @@ use crate::report;
 use crate::report::Fatal;
 use crate::report::Report;
 
+#[cfg(doc)]
+use crate::Span;
+
 /// A source context, which owns source code files.
 ///
 /// A `Context` contains the full text of all the loaded source files, which
-/// [`SpanId`]s ultimately refer to. Most [`SpanId`] operations need their
-/// corresponding `Context` available.
+/// [`Span`]s ultimately refer to.
 #[derive(Default)]
 pub struct Context {
   state: Arc<RwLock<State>>,

--- a/ilex/src/file/mod.rs
+++ b/ilex/src/file/mod.rs
@@ -302,7 +302,7 @@ pub trait Spanned<'ctx> {
   /// Returns the span in this syntax element.
   fn span(&self) -> Span<'ctx>;
 
-  /// Forwards to [`SpanId::file()`].
+  /// Forwards to [`Span::file()`].
   fn file(&self) -> File<'ctx> {
     self.span().file()
   }
@@ -327,7 +327,7 @@ pub trait Spanned<'ctx> {
     self.span().len()
   }
 
-  /// Forwards to [`SpanId::text()`].
+  /// Forwards to [`Span::text()`].
   fn text(&self) -> &'ctx str {
     self.span().text()
   }

--- a/ilex/src/file/mod.rs
+++ b/ilex/src/file/mod.rs
@@ -143,7 +143,7 @@ impl<'ctx> Span<'ctx> {
   pub(crate) fn new<T: Copy + TryInto<u32> + fmt::Debug>(
     file: File<'ctx>,
     range: impl RangeBounds<T>,
-  ) -> Span {
+  ) -> Self {
     let start = match range.start_bound() {
       Bound::Included(&x) => cast(x),
       Bound::Excluded(&x) => cast(x).saturating_add(1),
@@ -353,7 +353,7 @@ impl<'ctx> Spanned<'ctx> for Never {
 }
 
 thread_local! {
-  static CTX_FOR_SPAN_DEBUG: RefCell<Option<Context>> = RefCell::new(None);
+  static CTX_FOR_SPAN_DEBUG: RefCell<Option<Context>> = const { RefCell::new(None) };
 }
 
 impl fmt::Debug for File<'_> {

--- a/ilex/src/fp.rs
+++ b/ilex/src/fp.rs
@@ -17,7 +17,6 @@ use rustc_apfloat::Round;
 use rustc_apfloat::Status;
 use rustc_apfloat::StatusAnd;
 
-use crate::file::Context;
 use crate::file::Spanned;
 use crate::report::Report;
 use crate::token::Digital;
@@ -464,7 +463,6 @@ impl Digital<'_> {
   #[track_caller]
   pub(crate) fn parse_fp<Fp: Parse>(
     self,
-    ctx: &Context,
     report: &Report,
     exact: bool,
   ) -> Result<Fp, Exotic> {
@@ -595,7 +593,7 @@ impl Digital<'_> {
         value
       }
     } else {
-      fn has_ordinary_sign(ctx: &Context, tok: &Digital) -> bool {
+      fn has_ordinary_sign(tok: &Digital) -> bool {
         tok.sign().is_none()
           || tok.sign().is_some_and(|s| {
             matches!(
@@ -609,12 +607,12 @@ impl Digital<'_> {
       // underlying string. This is such a common format that we special case
       // it.
       if rule.point == "."
-        && has_ordinary_sign(ctx, &self)
+        && has_ordinary_sign(&self)
         && (exp.is_none()
           || exp.is_some_and(|exp| {
             exp.radix() == 10
               && (exp.has_prefix("e") || exp.has_prefix("E"))
-              && has_ordinary_sign(ctx, &exp)
+              && has_ordinary_sign(&exp)
           }))
         && (rule.separator.is_empty()
           || !self.text().contains(rule.separator.as_str()))

--- a/ilex/src/fp.rs
+++ b/ilex/src/fp.rs
@@ -521,7 +521,7 @@ impl Digital<'_> {
       let mut int_digits = 0i64;
       let mut frac_digits = 0i64;
       for (span, digits) in [(int, &mut int_digits), (frac, &mut frac_digits)] {
-        let Some(mut text) = span.map(|s| s.text(ctx)) else {
+        let Some(mut text) = span.map(|s| s.text()) else {
           continue;
         };
         while let Some(c) = text.chars().next() {
@@ -554,7 +554,7 @@ impl Digital<'_> {
       }
 
       if let Some(exp) = exp {
-        let mut text = exp.digit_blocks().next().unwrap().text(ctx);
+        let mut text = exp.digit_blocks().next().unwrap().text();
         while let Some(c) = text.chars().next() {
           if let Some(suf) = text.strip_prefix(rule.separator.as_str()) {
             text = suf;
@@ -599,7 +599,7 @@ impl Digital<'_> {
         tok.sign().is_none()
           || tok.sign().is_some_and(|s| {
             matches!(
-              (tok.sign_span().unwrap().text(ctx), s),
+              (tok.sign_span().unwrap().text(), s),
               ("+", Sign::Pos) | ("-", Sign::Neg)
             )
           })
@@ -617,13 +617,12 @@ impl Digital<'_> {
               && has_ordinary_sign(ctx, &exp)
           }))
         && (rule.separator.is_empty()
-          || !self.text(ctx).contains(rule.separator.as_str()))
+          || !self.text().contains(rule.separator.as_str()))
       {
-        let text = self.text(ctx);
+        let text = self.text();
         Fp::__parse(
-          &text[self.prefix().map(|s| s.text(ctx).len()).unwrap_or(0)
-            ..text.len()
-              - self.suffix().map(|s| s.text(ctx).len()).unwrap_or(0)],
+          &text[self.prefix().map(|s| s.text().len()).unwrap_or(0)
+            ..text.len() - self.suffix().map(|s| s.text().len()).unwrap_or(0)],
         )
       } else {
         // Since the fast paths have failed us, we need to construct a suitable
@@ -632,7 +631,7 @@ impl Digital<'_> {
         let buf = (|| {
           use std::fmt::Write;
 
-          let mut buf = String::with_capacity(self.text(ctx).len());
+          let mut buf = String::with_capacity(self.text().len());
           if self.is_negative() {
             buf.push('-');
           }
@@ -640,12 +639,12 @@ impl Digital<'_> {
           let _ = write!(
             buf,
             "{}",
-            u64::from_radix(int.unwrap().text(ctx), 10, &rule.separator)?
+            u64::from_radix(int.unwrap().text(), 10, &rule.separator)?
           );
 
           if let Some(frac) = frac {
             let sep = rule.separator.as_str();
-            let mut frac = frac.text(ctx);
+            let mut frac = frac.text();
             let mut lz = 0;
             loop {
               let start_len = frac.len();
@@ -688,7 +687,7 @@ impl Digital<'_> {
                 _ => '+',
               },
               u64::from_radix(
-                exp.digit_blocks().next().unwrap().text(ctx),
+                exp.digit_blocks().next().unwrap().text(),
                 exp.radix(),
                 &rule.separator
               )?,

--- a/ilex/src/ice.rs
+++ b/ilex/src/ice.rs
@@ -8,7 +8,7 @@ use std::backtrace::BacktraceStatus;
 use std::io;
 use std::panic;
 use std::panic::AssertUnwindSafe;
-use std::panic::PanicInfo;
+use std::panic::PanicHookInfo;
 use std::panic::UnwindSafe;
 use std::sync::Mutex;
 use std::thread;
@@ -148,7 +148,7 @@ impl Ice {
   ///
   /// The results are "best effort". The Rust backtrace API is incomplete, so we
   /// make do with some... cleverness around parsing the backtrace itself.
-  pub fn generate(panic: &PanicInfo, options: Options) -> Self {
+  pub fn generate(panic: &PanicHookInfo, options: Options) -> Self {
     let msg = panic.payload();
     let msg = Option::or(
       msg.downcast_ref::<&str>().copied().map(str::to_string),

--- a/ilex/src/lib.rs
+++ b/ilex/src/lib.rs
@@ -271,7 +271,7 @@ pub use {
   crate::{
     file::Context,
     file::File,
-    file::{Span, SpanId, Spanned},
+    file::{Span, Spanned},
     report::{Fatal, Report},
     rule::Rule,
     spec::{Lexeme, Spec, SpecBuilder},

--- a/ilex/src/report/builtin.rs
+++ b/ilex/src/report/builtin.rs
@@ -68,7 +68,6 @@ impl Builtins<'_> {
   #[track_caller]
   pub(crate) fn extra_chars<'a>(
     &self,
-
     unexpected_in: impl Into<Expected<'a>>,
     at: impl Spanned,
   ) -> Diagnostic {

--- a/ilex/src/report/diagnostic.rs
+++ b/ilex/src/report/diagnostic.rs
@@ -13,7 +13,7 @@ use crate::report::Report;
 /// almost always temporaries, e.g.
 ///
 /// ```
-/// # fn x(report: &ilex::Report, span: ilex::SpanId) {
+/// # fn x(report: &ilex::Report, span: ilex::Span) {
 /// report.error("my error message")
 ///   .saying(span, "this is bad code");
 /// # }

--- a/ilex/src/report/mod.rs
+++ b/ilex/src/report/mod.rs
@@ -17,8 +17,6 @@ use std::process;
 use std::sync::Arc;
 
 use crate::file::Context;
-#[cfg(doc)]
-use crate::file::SpanId;
 use crate::spec::Spec;
 
 mod builtin;

--- a/ilex/src/report/mod.rs
+++ b/ilex/src/report/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains types for generating an *error report*: a collection of
 //! diagnostics that describe why an operation failed in detail. Diagnostics
-//! are basically fancy compiler errors: they use [`SpanId`]s to present faulty
+//! are basically fancy compiler errors: they use [`Span`]s to present faulty
 //! input in context.
 //!
 //! The [`Report`] type is a reference-counted list of diagnostics, which is
@@ -28,10 +28,13 @@ pub use builtin::Expected;
 pub use diagnostic::Diagnostic;
 use diagnostic::Kind;
 
+#[cfg(doc)]
+use crate::Span;
+
 /// A collection of errors can may built up over the course of an operation.
 ///
 /// To construct a report, see [`Context::new_report()`]. The context that
-/// constructs a report is the only one whose [`SpanId`]s should be passed into
+/// constructs a report is the only one whose [`Span`]s should be passed into
 /// it; doing otherwise will result in unspecified output (or probably a panic).
 pub struct Report {
   ctx: Context,

--- a/ilex/src/report/mod.rs
+++ b/ilex/src/report/mod.rs
@@ -68,7 +68,7 @@ impl Report {
   /// Returns a wrapper for accessing commonly-used, built-in message types.
   ///
   /// See [`Builtins`].
-  pub fn builtins<'a>(&'a self, spec: &'a Spec) -> Builtins {
+  pub fn builtins<'a>(&'a self, spec: &'a Spec) -> Builtins<'a> {
     Builtins { report: self, spec }
   }
 

--- a/ilex/src/report/render.rs
+++ b/ilex/src/report/render.rs
@@ -134,8 +134,9 @@ pub fn render_fmt(
       let mut cur_file = None;
       let mut cur_slice = None::<Slice>;
       let mut has_eof = false;
-      for (range, text, kind) in snips {
-        let file = range.file(&report.ctx);
+      for (span, text, kind) in snips {
+        let span = span.get(&report.ctx);
+        let file = span.file();
         if cur_file != Some(file) {
           cur_file = Some(file);
           if let Some(mut slice) = cur_slice.take() {
@@ -155,8 +156,8 @@ pub fn render_fmt(
         }
 
         let slice = cur_slice.as_mut().unwrap();
-        let mut start = range.start();
-        let mut end = range.end();
+        let mut start = span.start();
+        let mut end = span.end();
 
         // Ensure that all ranges have length at least one, and try to get them
         // to point just after non-whitespace.

--- a/ilex/src/rt/dfa.rs
+++ b/ilex/src/rt/dfa.rs
@@ -103,7 +103,7 @@ impl Dfa {
         let id = dfa.match_pattern(lexer.cache(), state, i);
         if id.as_usize() < self.non_close_rules {
           Lexeme2 {
-            lexeme: Lexeme::new(id.as_u32()),
+            lexeme: Lexeme::new(id.as_i32()),
             is_close: false,
           }
         } else {
@@ -127,7 +127,7 @@ pub fn compile(rules: &[Any]) -> Dfa {
   let mut closers = Vec::new();
 
   for (lexeme, rule) in rules.iter().enumerate() {
-    let lexeme = Lexeme::new(lexeme as u32);
+    let lexeme = Lexeme::new(lexeme as i32);
     let rule = compile_rule(rule);
     patterns.push(rule.pat);
     if let Some(close) = rule.close {

--- a/ilex/src/rt/dfa.rs
+++ b/ilex/src/rt/dfa.rs
@@ -95,9 +95,7 @@ impl Dfa {
       }
     }
 
-    let Some((last_match, state)) = last_match else {
-      return None;
-    };
+    let (last_match, state) = last_match?;
     let candidates = (0..dfa.match_len(lexer.cache(), state))
       .map(|i| {
         let id = dfa.match_pattern(lexer.cache(), state, i);

--- a/ilex/src/rt/dfa.rs
+++ b/ilex/src/rt/dfa.rs
@@ -69,7 +69,7 @@ impl Dfa {
   /// length, plus potential lexical interpretations of that range.
   pub fn search(&self, lexer: &mut Lexer) -> Option<Match> {
     let dfa = &self.engine;
-    let haystack = lexer.rest();
+    let haystack = lexer.text(lexer.cursor()..);
 
     let mut state = dfa
       .start_state(lexer.cache(), &start::Config::new().anchored(Anchored::Yes))

--- a/ilex/src/rt/lexer.rs
+++ b/ilex/src/rt/lexer.rs
@@ -108,17 +108,17 @@ impl<'a, 'ctx> Lexer<'a, 'ctx> {
   }
 
   /// Returns the EOF span.
-  pub fn eof(&self) -> Span {
+  pub fn eof(&self) -> Span<'ctx> {
     self.file().span(self.file().len()..self.file().len())
   }
 
   /// Creates a new range in the current file.
-  pub fn span(&self, range: impl RangeBounds<usize>) -> Span {
+  pub fn span(&self, range: impl RangeBounds<usize>) -> Span<'ctx> {
     self.file().span(range)
   }
 
   // Returns the span of the token at the given index.
-  pub fn lookup_span(&self, idx: usize) -> Span {
+  pub fn lookup_span(&self, idx: usize) -> Span<'ctx> {
     let end = self.stream.toks[idx].end as usize;
     let start = self.stream.toks[..idx]
       .last()
@@ -188,7 +188,7 @@ impl<'a, 'ctx> Lexer<'a, 'ctx> {
         self.builtins().extra_chars(
           self.spec().rule_name_or(
             close.lexeme.any(),
-            f!("{} ... {}", open_sp.text(self.file().context()), close.close),
+            f!("{} ... {}", open_sp, close.close),
           ),
           span,
         );

--- a/ilex/src/rt/mod.rs
+++ b/ilex/src/rt/mod.rs
@@ -83,7 +83,7 @@ pub enum Kind {
   Keyword,
   Ident(SpanId),
   Quoted {
-    content: Vec<Content>,
+    content: Vec<Content<SpanId>>,
     open: SpanId,
     close: SpanId,
   },

--- a/ilex/src/rt/mod.rs
+++ b/ilex/src/rt/mod.rs
@@ -3,7 +3,7 @@
 use std::cell::Cell;
 
 use crate::file::File;
-use crate::file::SpanId;
+use crate::file::Span;
 use crate::report::Fatal;
 use crate::report::Report;
 use crate::rule;
@@ -106,10 +106,35 @@ pub struct Digital {
 
 #[derive(Clone, Default)]
 pub struct DigitBlocks {
-  pub prefix: Option<SpanId>,
-  pub sign: Option<(Sign, SpanId)>,
-  pub blocks: Vec<SpanId>,
+  pub prefix: [u32; 2],
+  pub sign: Option<(Sign, [u32; 2])>,
+  pub blocks: Vec<[u32; 2]>,
   pub which_exp: usize,
+}
+
+impl DigitBlocks {
+  pub fn prefix(&self, file: File) -> Option<Span> {
+    if self.prefix == [0, 0] {
+      return None;
+    }
+    Some(file.span(self.prefix[0] as usize..self.prefix[1] as usize))
+  }
+
+  pub fn sign(&self, file: File) -> Option<Span> {
+    self
+      .sign
+      .map(|(_, [a, b])| file.span(a as usize..b as usize))
+  }
+
+  pub fn blocks<'a>(
+    &'a self,
+    file: File<'a>,
+  ) -> impl Iterator<Item = Span> + 'a {
+    self
+      .blocks
+      .iter()
+      .map(move |&[a, b]| file.span(a as usize..b as usize))
+  }
 }
 
 pub const WHITESPACE: Lexeme<rule::Any> = Lexeme::new(-1);

--- a/ilex/src/rule.rs
+++ b/ilex/src/rule.rs
@@ -1060,7 +1060,7 @@ impl TryFrom<Any> for Digital {
 ///
 /// Comments do not generate tokens, unlike most rules. Instead, they are
 /// attached to the span of a token, and can be inspected through
-/// [`Span::comments()`][crate::Span::comments].
+/// [`Token::comments()`][crate::Token::comments].
 #[derive(Debug)]
 pub struct Comment {
   pub(crate) bracket: Bracket,

--- a/ilex/src/spec.rs
+++ b/ilex/src/spec.rs
@@ -54,7 +54,9 @@ impl<R> Lexeme<R> {
 
   /// Returns whether this lexeme can have comments attached to it.
   pub(crate) fn can_have_comments(self, spec: &Spec) -> bool {
-    !self.is_aux() && !matches!(spec.rule(self.any()), rule::Any::Comment(_))
+    !self.is_aux()
+      && (self.is_eof()
+        || !matches!(spec.rule(self.any()), rule::Any::Comment(_)))
   }
 
   /// Converts this lexeme into an index.
@@ -68,7 +70,7 @@ impl<R> Lexeme<R> {
   }
 
   /// Creates a new lexeme.
-  pub(crate) fn new(id: i32) -> Self {
+  pub(crate) const fn new(id: i32) -> Self {
     Self { id, _ph: PhantomData }
   }
 }

--- a/ilex/src/spec.rs
+++ b/ilex/src/spec.rs
@@ -4,7 +4,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Display;
 use std::hash::Hash;
-use std::i32;
 use std::marker::PhantomData;
 
 use byteyarn::yarn;

--- a/ilex/src/testing/mod.rs
+++ b/ilex/src/testing/mod.rs
@@ -330,7 +330,7 @@ impl Text {
 
   /// Returns whether this span recognizes a particular span.
   fn recognizes(&self, span: Span) -> bool {
-    !self.text.as_ref().is_some_and(|text| text != span.text())
+    self.text.as_ref().is_none_or(|text| text == span.text())
       && !self.range.as_ref().is_some_and(|range| {
         let r = span.span();
         range != &(r.start()..r.end())

--- a/ilex/src/testing/mod.rs
+++ b/ilex/src/testing/mod.rs
@@ -333,12 +333,9 @@ impl Text {
 
   /// Returns whether this span recognizes a particular span.
   fn recognizes(&self, span: Span, ctx: &Context) -> bool {
-    !self
-      .text
-      .as_ref()
-      .is_some_and(|text| text != span.text(ctx))
+    !self.text.as_ref().is_some_and(|text| text != span.text())
       && !self.range.as_ref().is_some_and(|range| {
-        let r = span.span(ctx);
+        let r = span.span();
         range != &(r.start()..r.end())
       })
   }

--- a/ilex/src/testing/recognize.rs
+++ b/ilex/src/testing/recognize.rs
@@ -64,7 +64,7 @@ impl Matcher {
     tok: token::Any,
     ctx: &Context,
   ) {
-    state.match_spans("token span", &self.span, Spanned::span(&tok, ctx));
+    state.match_spans("token span", &self.span, Spanned::span(&tok));
 
     zip_eq("comments", state, &self.comments, tok.comments(), |state, t, s| {
       state.match_spans("comment", t, s);
@@ -267,20 +267,25 @@ impl<'a> MatchState<'a> {
     let _ = writeln!(self.errors, ": {msg}");
   }
 
-  fn match_spans(&mut self, what: &str, text: &Text, span: impl Spanned) {
-    let span = span.span(self.ctx);
+  fn match_spans<'s>(
+    &mut self,
+    what: &str,
+    text: &Text,
+    span: impl Spanned<'s>,
+  ) {
+    let span = span.span();
     if !text.recognizes(span, self.ctx) {
       self.error(f!("wrong {what}; want {:?}, got {:?}", text, span));
     }
   }
 
-  fn match_options(
+  fn match_options<'s>(
     &mut self,
     what: &str,
     text: Option<&Text>,
-    span: Option<impl Spanned>,
+    span: Option<impl Spanned<'s>>,
   ) {
-    let span = span.map(|s| s.span(self.ctx));
+    let span = span.map(|s| s.span());
     if text.is_none() && span.is_none() {
       return;
     }

--- a/ilex/src/testing/recognize.rs
+++ b/ilex/src/testing/recognize.rs
@@ -16,6 +16,7 @@ use crate::testing::Text;
 use crate::token;
 use crate::token::Any;
 use crate::token::Sign;
+use crate::token::Token;
 
 pub struct Matcher {
   pub which: Option<Lexeme<rule::Any>>,
@@ -65,15 +66,9 @@ impl Matcher {
   ) {
     state.match_spans("token span", &self.span, Spanned::span(&tok, ctx));
 
-    zip_eq(
-      "comments",
-      state,
-      &self.comments,
-      &tok.comments(ctx),
-      |state, t, s| {
-        state.match_spans("comment", t, s);
-      },
-    );
+    zip_eq("comments", state, &self.comments, tok.comments(), |state, t, s| {
+      state.match_spans("comment", t, s);
+    });
 
     match (&self.kind, tok) {
       (Kind::Eof, Any::Eof(..)) | (Kind::Keyword, Any::Keyword(..)) => {}

--- a/ilex/src/testing/recognize.rs
+++ b/ilex/src/testing/recognize.rs
@@ -83,7 +83,7 @@ impl Matcher {
         state.match_options("suffix", suffix.as_ref(), tok.suffix());
       }
       (Kind::Quoted { delims, content, prefix, suffix }, Any::Quoted(tok)) => {
-        let (open, close) = tok.delimiters();
+        let [open, close] = tok.delimiters();
         state.match_spans("open quote", &delims.0, open);
         state.match_spans("close quote", &delims.1, close);
         state.match_options("prefix", prefix.as_ref(), tok.prefix());

--- a/ilex/src/token/mod.rs
+++ b/ilex/src/token/mod.rs
@@ -1000,7 +1000,7 @@ impl<'lex> Quoted<'lex> {
   /// Returns the raw content of this token.
   ///
   /// There are two kinds of content: either a literal span of Unicode scalars
-  /// (represented as a [`SpanId`] pointing to those characters) or a single
+  /// (represented as a [`Span`] pointing to those characters) or a single
   /// escape, potentially with some side data.
   ///
   /// It is up to the user of the library to decode these two content types into

--- a/ilex/src/token/mod.rs
+++ b/ilex/src/token/mod.rs
@@ -758,7 +758,7 @@ impl<'lex> Digital<'lex> {
     range: impl RangeBounds<Fp>,
     report: &Report,
   ) -> Result<Fp, fp::Exotic> {
-    let fp: Fp = self.parse_fp(self.context(), report, false)?;
+    let fp: Fp = self.parse_fp(report, false)?;
 
     if !fp.__is_finite() || !range.contains(&fp) {
       report.builtins(self.spec()).literal_out_of_range(
@@ -784,7 +784,7 @@ impl<'lex> Digital<'lex> {
     range: impl RangeBounds<Fp>,
     report: &Report,
   ) -> Result<Fp, fp::Exotic> {
-    let fp: Fp = self.parse_fp(self.context(), report, true)?;
+    let fp: Fp = self.parse_fp(report, true)?;
 
     if !fp.__is_finite() || !range.contains(&fp) {
       report.builtins(self.spec()).literal_out_of_range(
@@ -1231,7 +1231,6 @@ impl<'lex> Any<'lex> {
       return name.to_box();
     }
 
-    let ctx = self.context();
     let (pre, suf, kind) = match self {
       Any::Eof(_) => return yarn!("<eof>"),
       Any::Keyword(tok) => return yarn!("`{}`", tok.text()),

--- a/ilex/src/token/stream.rs
+++ b/ilex/src/token/stream.rs
@@ -536,13 +536,12 @@ pub struct Comments<'lex> {
 impl<'lex> Comments<'lex> {
   /// Adapts this iterator to return just the text contents of each [`SpanId`].
   pub fn as_strings(self) -> impl Iterator<Item = &'lex str> + 'lex {
-    let ctx = self.stream.context();
-    self.map(move |s| s.text(ctx))
+    self.map(Span::text)
   }
 }
 
 impl<'lex> Iterator for Comments<'lex> {
-  type Item = Span;
+  type Item = Span<'lex>;
 
   fn next(&mut self) -> Option<Self::Item> {
     let id = *self.comments.next()?;

--- a/ilex/src/token/stream.rs
+++ b/ilex/src/token/stream.rs
@@ -101,7 +101,7 @@ impl<'ctx> Stream<'ctx> {
       return Some(token::Eof { stream: self, id }.into());
     }
 
-    return Some(match self.spec().rule(tok.lexeme) {
+    Some(match self.spec().rule(tok.lexeme) {
       rule::Any::Comment(..) => return None,
       rule::Any::Keyword(..) => token::Keyword { stream: self, id }.into(),
       rule::Any::Ident(..) => token::Ident { stream: self, id }.into(),
@@ -144,7 +144,7 @@ impl<'ctx> Stream<'ctx> {
 
         token::Digital { stream: self, id, meta, idx: 0 }.into()
       }
-    });
+    })
   }
 
   pub(crate) fn lookup_meta(&self, id: token::Id) -> Option<&rt::Metadata> {
@@ -374,7 +374,7 @@ impl<'lex> Cursor<'lex> {
     &'a mut self,
     delim: Lexeme<R>,
     mut cb: impl FnMut(&mut Self) -> Option<T> + 'a,
-  ) -> impl Iterator<Item = (T, Option<R::Token<'lex>>)> + '_ {
+  ) -> impl Iterator<Item = (T, Option<R::Token<'lex>>)> + 'a {
     let mut sep = switch::switch().case(delim, |x, _| x);
     let mut done = false;
     let mut prev = self.cursor;

--- a/ilex/src/token/stream.rs
+++ b/ilex/src/token/stream.rs
@@ -534,7 +534,7 @@ pub struct Comments<'lex> {
 }
 
 impl<'lex> Comments<'lex> {
-  /// Adapts this iterator to return just the text contents of each [`SpanId`].
+  /// Adapts this iterator to return just the text contents of each [`Span`].
   pub fn as_strings(self) -> impl Iterator<Item = &'lex str> + 'lex {
     self.map(Span::text)
   }

--- a/ilex/tests/greedy.rs
+++ b/ilex/tests/greedy.rs
@@ -48,5 +48,5 @@ fn greedy() {
     .then2(array, ("[", "]"), Matcher::new().then1(ident, "xyz"))
     .then2(cpp_like, ("R\"cc(", ")cc\""), ["some c++)\" "])
     .eof()
-    .assert_matches(&ctx, &tokens);
+    .assert_matches(&tokens);
 }

--- a/ilex/tests/json.rs
+++ b/ilex/tests/json.rs
@@ -249,7 +249,7 @@ fn parse0(
 ) -> Json {
   let quote2str = |str: token::Quoted| -> String {
     str.to_utf8(|key, data, buf| {
-      let char = match key.text(ctx) {
+      let char = match key.text() {
         "\\\"" => '\"',
         r"\\" => '\\',
         r"\/" => '/',
@@ -262,10 +262,10 @@ fn parse0(
         r"\u" => {
           let data = data.unwrap();
           let code =
-            u16::from_str_radix(data.text(ctx), 16).unwrap_or_else(|_| {
+            u16::from_str_radix(data.text(), 16).unwrap_or_else(|_| {
               report.builtins(json.spec()).expected(
                 [Expected::Name("hex-encoded u16".into())],
-                data.text(ctx),
+                data.text(),
                 data,
               );
               0

--- a/ilex/tests/json.rs
+++ b/ilex/tests/json.rs
@@ -11,7 +11,6 @@ use ilex::token;
 use ilex::token::Content as C;
 use ilex::token::Cursor;
 use ilex::Lexeme;
-use ilex::Spanned;
 
 #[ilex::spec]
 struct JsonSpec {

--- a/ilex/tests/json.rs
+++ b/ilex/tests/json.rs
@@ -167,7 +167,7 @@ fn check_tokens() {
         ),
     )
     .eof()
-    .assert_matches(&ctx, &tokens);
+    .assert_matches(&tokens);
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -236,17 +236,12 @@ fn parse(data: &str) -> Result<Json, impl fmt::Debug> {
     .new_file("<i>", data)
     .lex(json.spec(), &report)
     .map_err(|e| Error(e.to_string()))?;
-  let value = parse0(&ctx, &report, json, &mut stream.cursor());
+  let value = parse0(&report, json, &mut stream.cursor());
 
   report.fatal_or(value).map_err(|e| Error(e.to_string()))
 }
 
-fn parse0(
-  ctx: &ilex::Context,
-  report: &Report,
-  json: &JsonSpec,
-  cursor: &mut Cursor,
-) -> Json {
+fn parse0(report: &Report, json: &JsonSpec, cursor: &mut Cursor) -> Json {
   let quote2str = |str: token::Quoted| -> String {
     str.to_utf8(|key, data, buf| {
       let char = match key.text() {
@@ -293,7 +288,7 @@ fn parse0(
       let mut trailing = None;
       let vec = array
         .contents()
-        .delimited(json.comma, |c| Some(parse0(ctx, report, json, c)))
+        .delimited(json.comma, |c| Some(parse0(report, json, c)))
         .map(|(e, c)| {
           trailing = c;
           e
@@ -318,7 +313,7 @@ fn parse0(
             .map(|q| quote2str(q))
             .unwrap_or("😢".into());
           c.take(json.colon, report);
-          let value = parse0(ctx, report, json, c);
+          let value = parse0(report, json, c);
           Some((key, value))
         })
         .map(|(e, c)| {

--- a/ilex/tests/llvm.rs
+++ b/ilex/tests/llvm.rs
@@ -280,5 +280,5 @@ fn llvm() {
         .then1(llvm.void, "void"),
     )
     .eof()
-    .assert_matches(&ctx, &tokens)
+    .assert_matches(&tokens)
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.83.0"
 profile = "default"


### PR DESCRIPTION
This PR adds a bunch of layout optimizations to `token::Stream`. It also:

- Eliminates a lot annoying `ilex::Context` passing.
- Makes `Span` remember the file it points to, in service of the former.
- Eliminates `SpanId`, which is no longer needed due to layout optimizations.