### PR TITLE
Byteyarn: Add `no_std` support

### DIFF
--- a/byteyarn/src/boxed.rs
+++ b/byteyarn/src/boxed.rs
@@ -1,15 +1,18 @@
-use std::alloc::Layout;
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::ptr::NonNull;
-use std::slice;
-use std::str;
-use std::str::Utf8Error;
+use ::alloc::boxed::Box;
+use ::alloc::string::String;
+use ::alloc::vec::Vec;
+use core::alloc::Layout;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::Hash;
+use core::hash::Hasher;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Deref;
+use core::ptr::NonNull;
+use core::slice;
+use core::str;
+use core::str::Utf8Error;
 
 use crate::raw::RawYarn;
 use crate::Utf8Chunks;
@@ -328,11 +331,11 @@ where
         let layout = buf_trait::layout_of(self.as_slice());
         let ptr = match layout.size() {
           0 => NonNull::<Buf::Element>::dangling().as_ptr() as *mut u8,
-          _ => std::alloc::alloc(layout),
+          _ => alloc::alloc::alloc(layout),
         };
 
         if ptr.is_null() {
-          std::alloc::handle_alloc_error(layout);
+          alloc::alloc::handle_alloc_error(layout);
         }
 
         let raw = self.into_raw();

--- a/byteyarn/src/convert.rs
+++ b/byteyarn/src/convert.rs
@@ -1,6 +1,9 @@
-use std::borrow::Borrow;
-use std::fmt;
-use std::str::Utf8Error;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::fmt;
+use core::str::Utf8Error;
 
 use crate::YarnBox;
 use crate::YarnRef;

--- a/byteyarn/src/lib.rs
+++ b/byteyarn/src/lib.rs
@@ -68,9 +68,12 @@
 //! ```
 
 #![deny(missing_docs)]
+#![no_std]
+
+extern crate alloc;
 
 #[cfg(doc)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 mod boxed;
 mod convert;
@@ -87,7 +90,7 @@ pub use buf_trait::Buf;
 // Macro stuff.
 #[doc(hidden)]
 pub mod m {
-  pub extern crate std;
+  pub extern crate core as std;
 }
 
 /// An optimized Unicode string.

--- a/byteyarn/src/raw.rs
+++ b/byteyarn/src/raw.rs
@@ -1,12 +1,14 @@
-use std::alloc;
-use std::fmt;
-use std::fmt::Write;
-use std::mem;
-use std::mem::ManuallyDrop;
-use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
-use std::ptr;
-use std::slice;
+use ::alloc::boxed::Box;
+use ::alloc::vec::Vec;
+use core::alloc;
+use core::fmt;
+use core::fmt::Write;
+use core::mem;
+use core::mem::ManuallyDrop;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+use core::ptr;
+use core::slice;
 
 /// The core implementation of yarns.
 ///
@@ -237,7 +239,7 @@ impl RawYarn {
     }
 
     debug_assert!(layout.size() > 0);
-    alloc::dealloc(self.ptr as *mut u8, layout)
+    ::alloc::alloc::dealloc(self.ptr as *mut u8, layout)
   }
 
   /// Returns a pointer into the data for this raw yarn.
@@ -326,7 +328,7 @@ impl RawYarn {
       // SAFETY: This is a precondition for this function.
       // This allows the compiler to assume len <= Self::SSO_LEN for the rest
       // of the function body.
-      std::hint::unreachable_unchecked();
+      core::hint::unreachable_unchecked();
     }
 
     let tagged_len = (len as u8) | Self::SMALL << Self::SHIFT8;
@@ -579,9 +581,9 @@ impl AlignedBox {
     layout: alloc::Layout,
     slices: impl IntoIterator<Item = &'a [u8]>,
   ) -> Self {
-    let mut ptr = alloc::alloc(layout);
+    let mut ptr = ::alloc::alloc::alloc(layout);
     if ptr.is_null() {
-      alloc::handle_alloc_error(layout);
+      ::alloc::alloc::handle_alloc_error(layout);
     }
 
     for slice in slices {
@@ -626,9 +628,9 @@ impl Drop for AlignedBox {
       ManuallyDrop::new(mem::replace(&mut self.data, [].into())).as_mut_ptr();
 
     unsafe {
-      alloc::dealloc(
+      ::alloc::alloc::dealloc(
         ptr,
-        alloc::Layout::from_size_align_unchecked(len, self.align),
+        ::alloc::alloc::Layout::from_size_align_unchecked(len, self.align),
       )
     }
   }

--- a/byteyarn/src/reffed.rs
+++ b/byteyarn/src/reffed.rs
@@ -1,13 +1,16 @@
-use std::cmp::Ordering;
-use std::fmt;
-use std::fmt::Write;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::str;
-use std::str::Utf8Error;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt;
+use core::fmt::Write;
+use core::hash::Hash;
+use core::hash::Hasher;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Deref;
+use core::str;
+use core::str::Utf8Error;
 
 use crate::raw::RawYarn;
 use crate::Utf8Chunks;

--- a/byteyarn/src/utf8.rs
+++ b/byteyarn/src/utf8.rs
@@ -1,6 +1,6 @@
 //! UTF-8 utilities not provided by the standard library.
 
-use std::str;
+use core::str;
 
 #[cfg(doc)]
 use crate::*;


### PR DESCRIPTION
Most of this PR is just changing `std` to `core`/`alloc`.

A couple off modules imported `std::alloc` which creates a problem when using anything from `liballoc`, so I used `::alloc::..` in a number of places, IMO a bit smelly but the easiest and least invasive option. 

Usually `no_std` compatible crates include a "std" default feature flag to enable `libstd` but nothing in byteyarn actually uses `libstd` so I didn't bother. This *may* create a breaking change in the future if `libstd` is ever required so I can add a feature flag if you want.

```
pub mod m {
    pub extern std;
}
```
is in lib.rs, for "Macro stuff" which I've changed to `pub extern crate core as std;` for fear of breaking things. From what I can see this is required by the `yarn!` macro. It may be better to remove this entirely and change `yarn!` to use `::core::fmt::format_args!` instead.